### PR TITLE
Multiple destinations for trips and an install script

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -3,7 +3,7 @@ var config = {
     // Lenguage for the mirror
     language : "en", //must also manually update locales/X.js bower component in index.html
     layout: "main",
-    greeting : ["Hi, sexy!"], // An array of greetings to randomly choose from
+    greeting : ["Hi, sexy!", "Greetings, commander"], // An array of greetings to randomly choose from
     
     // Alternativly you can have greetings that appear based on the time of day
     /*
@@ -28,7 +28,7 @@ var config = {
     },
     // Calendar (An array of iCals)
     calendar: {
-      icals : [],
+      icals : [], // Be sure to wrap your URLs in quotes
       maxResults: 9, // Number of calender events to display (Defaults is 9)
       maxDays: 365 // Number of days to display (Default is one year)
     },
@@ -38,10 +38,13 @@ var config = {
     },
     traffic: {
       key : "", // Bing Maps API Key
-      mode : "Driving", // Possibilities: Driving / Transit / Walking
-      origin : "", // Start of your trip. Human readable address.
-      destination : "", // Destination of your trip. Human readable address.
-      name : "work", // Name of your destination ex: "work"
-      reload_interval : 5 // Number of minutes the information is refreshed
+      reload_interval : 5, // Number of minutes the information is refreshed
+      // An array of tips that you would like to display travel time for
+      trips : [{
+        mode : "Driving", // Possibilities: Driving / Transit / Walking
+        origin : "", // Start of your trip. Human readable address.
+        destination : "", // Destination of your trip. Human readable address.
+        name : "work", // Name of your destination ex: "work"
+      }]
     }
 };

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             <span ng-init="iconLoad('icon_weather_'+forcast.counter, forcast.iconAnimation)"></span>
           </div>
         </div>
-        <div class="traffic">
+        <div class="traffic" ng-repeat="traffic in trips">
           <div ng-show="!traffic.error" class="traffic-information">
             <span class="time-to">{{ 'traffic.time_to' | translate:traffic }}</span>
             <span>{{traffic.duration.humanize()}}</span>

--- a/js/controller.js
+++ b/js/controller.js
@@ -134,12 +134,10 @@
             $interval(greetingUpdater, 120000);
 
             var refreshTrafficData = function() {
-                TrafficService.getTravelDuration().then(function(durationTraffic) {
-                    console.log("Traffic", durationTraffic);
-                    $scope.traffic = {
-                        destination: config.traffic.name,
-                        duration : durationTraffic
-                    };
+                TrafficService.getDurationForTrips().then(function(tripsWithTraffic) {
+                    console.log("Traffic", tripsWithTraffic);
+                    //Todo this needs to be an array of traffic objects -> $trips[]
+                    $scope.trips = tripsWithTraffic;
                 }, function(error){
                     $scope.traffic = {error: error};
                 });

--- a/js/traffic-service.js
+++ b/js/traffic-service.js
@@ -3,21 +3,34 @@
 
     function TrafficService($http, $q) {
         var service = {};
-        var duration = null;
         var BING_MAPS = "http://dev.virtualearth.net/REST/V1/Routes/"
 
-        service.getTravelDuration = function(){
-          var deferred = $q.defer();
+        service.getDurationForTrips = function(){
+            var deferred = $q.defer();
+            var promises = [];
           
-          // Request traffic info for the configured mode of transport
-          $http.get(getEndpoint(config.traffic.mode))
-          .then(function(response){
+            angular.forEach(config.traffic.trips, function(trip) {
+                promises.push(getTripDuration(trip));
+            });
+            
+            $q.all(promises).then(function(data) {
+                deferred.resolve(data)
+            });
+            
+            return deferred.promise;
+        };
+        
+        // Request traffic info for the configured mode of transport
+        function getTripDuration(trip){
+          var deferred = $q.defer();
+          $http.get(getEndpoint(trip)).then(function(response){
             // Walking and Transit are "not effected" by traffic so we don't use their traffic duration
-            if(config.traffic.mode == "Transit" || config.traffic.mode == "Walking"){
-                deferred.resolve(moment.duration(response.data.resourceSets[0].resources[0].travelDuration, 'seconds'));
+            if(trip.mode == "Transit" || trip.mode == "Walking"){
+                trip.duration = moment.duration(response.data.resourceSets[0].resources[0].travelDuration, 'seconds');
             } else {
-                deferred.resolve(moment.duration(response.data.resourceSets[0].resources[0].travelDurationTraffic, 'seconds'));
+                trip.duration = moment.duration(response.data.resourceSets[0].resources[0].travelDurationTraffic, 'seconds')
             }
+            deferred.resolve(trip);
           }, function(error) {
             // Most of the time this is because an address can't be found
             if (error.status === 404) {
@@ -30,16 +43,16 @@
             duration = deferred.promise;
           });
           return deferred.promise;
-        };
+        }
         
         // Depending on the mode of transport different paramaters are required.
-        function getEndpoint(mode){
-            var endpoint = BING_MAPS + mode + "?wp.0=" + config.traffic.origin + "&wp.1="+config.traffic.destination;
-            if(mode == "Driving"){
+        function getEndpoint(trip){
+            var endpoint = BING_MAPS + trip.mode + "?wp.0=" + trip.origin + "&wp.1="+trip.destination;
+            if(trip.mode == "Driving"){
                 endpoint += "&avoid=minimizeTolls";
-            } else if(mode == "Transit"){
+            } else if(trip.mode == "Transit"){
                 endpoint += "&timeType=Departure&dateTime=" + moment().format('h:mm:ssa').toUpperCase();
-            } else if(mode == "Walking"){
+            } else if(trip.mode == "Walking"){
                 endpoint += "&optmz=distance";
             }
             endpoint += "&key=" + config.traffic.key;

--- a/locales/de.json
+++ b/locales/de.json
@@ -3,7 +3,7 @@
       "commands" : "Sagen Sie \"Was kann ich sagen?\" eine Liste von Befehlen zu sehen..."
     },
     "traffic" : {
-        "time_to" : "Zeit zu {{destination}}: "
+        "time_to" : "Zeit zu {{name}}: "
     },
     "timer": {
       "one": "Eine",

--- a/locales/en.json
+++ b/locales/en.json
@@ -3,7 +3,7 @@
         "commands" : "Say \"What can I say?\" to see a list of commands..."
     },
     "traffic" : {
-        "time_to" : "Time to {{destination}}: "
+        "time_to" : "Time to {{name}}: "
     },
     "timer": {
       "one": "One",

--- a/locales/es.json
+++ b/locales/es.json
@@ -3,7 +3,7 @@
         "commands" : "Dí \"¿Qué digo?\" para mostrar las órdenes..."
     },
     "traffic" : {
-        "time_to" : "Tiempo al {{destination}}: "
+        "time_to" : "Tiempo al {{name}}: "
     },
     "timer": {
       "one": "Uno",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3,7 +3,7 @@
         "commands" : "Dis: \"Que puis-je dire?\" pour voir une liste de commandes..."
     },
     "traffic" : {
-        "time_to" : "Temps de {{destination}}: "
+        "time_to" : "Temps de {{name}}: "
     },
     "timer": {
       "one": "Une",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -3,7 +3,7 @@
         "commands" : "Say \"사용가능한 질문\" to see a list of commands..."
     },
     "traffic" : {
-        "time_to" : "{{destination}} 에 시간: "
+        "time_to" : "{{name}} 에 시간: "
     },
     "timer": {
       "one": "일",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+# Any subsequent(*) commands which fail will cause the shell script to exit immediately
+set -e
+
 # Supported versions of node: v4.x, v5.x
 NODE_VERSION="v4.*\|v5.*"
 
-# Ensure we are not using sudo (this could cause bad things to happen)
-if [ "$(whoami)" == "root" ];
+# Ensure we are using sudo
+if [ "$(whoami)" != "root" ];
 then
-	echo "Sorry, this script should not be run with 'sudo'."
-	exit 1
+	echo "This script requires root permissions, try: sudo ./${0##*/} "
+	exit 0
 fi
 
 cat << "EOF"
@@ -24,79 +27,96 @@ cat << "EOF"
 |\   _ \  _   \|\  \|\   __  \|\   __  \|\   __  \|\   __  \    
 \ \  \\\__\ \  \ \  \ \  \|\  \ \  \|\  \ \  \|\  \ \  \|\  \   
  \ \  \\|__| \  \ \  \ \   _  _\ \   _  _\ \  \\\  \ \   _  _\  
-  \ \  \    \ \  \ \  \ \  \\  \\ \  \\  \\ \  \\\  \ \  \\  \| 
+  \ \  \    \ \  \ \  \ \  \\  \\ \  \\  \\ \  \\\  \ \  \\  \  
    \ \__\    \ \__\ \__\ \__\\ _\\ \__\\ _\\ \_______\ \__\\ _\ 
     \|__|     \|__|\|__|\|__|\|__|\|__|\|__|\|_______|\|__|\|__|
 
 EOF
 
-echo "This script will install the smart-mirror and it's dependencies."
+printf "This script will install the smart-mirror and it's dependencies.\n"
 
-
+# Ensure the use would like to start the install
 read -r -p "Would you like to continue? [y/N] " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
 then
-    echo "Excellent!"
+    printf "Excellent! $(tput setaf 9)Please do not exit this script until it is complete.$(tput sgr0)\n"
 else
     exit 1
 fi
 
+printf "\n"
 read -r -p "[Requires Reboot] Would you like to automoticlly rotate your monitor? [y/N]" rotateResponse
 if [[ $rotateResponse =~ ^([yY][eE][sS]|[yY])$ ]]
 then
-   # Rotate Display
+   # Rotate Display (replace the display_rotate line with display_rotate=1)
     sed -i -e '$a\
-    display_rotate=1' /boot/config.txt
+\
+#Rotate the display (smart-mirror)\
+display_rotate=1' /boot/config.txt
 fi
 
-echo "Checking for node"
+printf "\nChecking for node...\n"
 node --version | grep ${NODE_VERSION}
 if [[ $? != 0 ]] ;
 then
     # Install Node
-    echo "$(tput setaf 9)Downloading Node$(tput sgr0)"
+    printf "$(tput setaf 12)Downloading node$(tput sgr0)\n"
     wget https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv7l.tar.gz
     tar -xvf node-v4.0.0-linux-armv7l.tar.gz 
     cd node-v4.0.0-linux-armv7l
     
     # Copy to /usr/local
-    echo "$(tput setaf 9)Installing Node$(tput sgr0)"
+    printf "$(tput setaf 12)Installing node$(tput sgr0)\n"
     sudo cp -R * /usr/local/
     
     # Clean up after ourselvs
     cd ..
     rm node-v4.0.0-linux-armv7l.tar.gz
     rm -R node-v4.0.0-linux-armv7l
-    echo "$(tput setaf 10)Node is now installed!$(tput sgr0)"
+    printf "$(tput setaf 10)node is now installed!$(tput sgr0)\n"
 else
-    echo "$(tput setaf 10)node is already installed, great job!$(tput sgr0)"
+    printf "$(tput setaf 10)node is already installed, great job!$(tput sgr0)\n"
 fi
 
 # Getting the code
-echo "$(tput setaf 9)Cloning Git Repo$(tput sgr0)"
-cd ~
-git clone https://github.com/evancohen/smart-mirror.git
-echo "$(tput setaf 10)smart-mirror code is now downloaded$(tput sgr0)"
+printf "\n$(tput setaf 12)Cloning Git Repo$(tput sgr0)\n"
+cd /home/$LOGNAME
+sudo -u $LOGNAME git clone https://github.com/evancohen/smart-mirror.git
+printf "\n$(tput setaf 10)smart-mirror code is now downloaded$(tput sgr0)\n"
 
 cd smart-mirror
 
-echo "$(tput setaf 9)Creating Mirror Config$(tput sgr0)"
-cp config.example.js config.js
+printf "$(tput setaf 12)generating config template$(tput sgr0)\n"
+sudo -u $LOGNAME cp config.example.js config.js
 
 # Install package to hide the mouse when inactive
-echo "$(tput setaf 9)Installing unclutter$(tput sgr0)"
+printf "\n$(tput setaf 12)Installing unclutter$(tput sgr0)\n"
 sudo apt-get install unclutter
 
 # Apply LXDE unclutter autostart 
 sed -i -e '$a\
+\
+#Hide the mouse when inactive (smart-mirror)\
 unclutter -idle 0.1 -root' /etc/xdg/lxsession/LXDE/autostart
 
-echo "$(tput setaf 9)Installing smart-mirror dependencies...$(tput sgr0)"
-echo "$(tput setaf 11)This may take a bit$(tput sgr0)"
-npm install
-echo "$(tput setaf 10)The smart-mirror is now installed!$(tput sgr0)"
+printf "\n$(tput setaf 12)Installing smart-mirror dependencies...$(tput sgr0)\n"
+printf "$(tput setaf 11)This may take a while. Go grab a beer :)$(tput sgr0)\n"
+sudo -u $LOGNAME npm install
 
-# Launching Smart Mirror App
-npm start
+# The mirror is now installed, yay!
+cat << "EOF"
+
+        |        The smart-mirror is now installed!
+       / \       
+      / _ \      Once you fill out your config you can start the mirror with:
+     |.o '.|     npm start
+     |'._.'|     
+     |     |     To lean more, check out the documentation at:
+   ,'|  |  |`.   docs.smart-mirror.io
+  /  |  |  |  \
+  |,-'--|--'-.|
+  
+EOF
+# ASCII art found on http://textart.io/
 
 exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,6 +41,14 @@ else
     exit 1
 fi
 
+read -r -p "[Requires Reboot] Would you like to automoticlly rotate your monitor? [y/N]" rotateResponse
+if [[ $rotateResponse =~ ^([yY][eE][sS]|[yY])$ ]]
+then
+   # Rotate Display
+    sed -i -e '$a\
+    display_rotate=1' /boot/config.txt
+fi
+
 echo "Checking for node"
 node --version | grep ${NODE_VERSION}
 if [[ $? != 0 ]] ;
@@ -82,10 +90,6 @@ sudo apt-get install unclutter
 # Apply LXDE unclutter autostart 
 sed -i -e '$a\
 unclutter -idle 0.1 -root' /etc/xdg/lxsession/LXDE/autostart
-
-# Rotate Display
-sed -i -e '$a\
-display_rotate=1' /boot/config.txt
 
 echo "$(tput setaf 9)Installing smart-mirror dependencies...$(tput sgr0)"
 echo "$(tput setaf 11)This may take a bit$(tput sgr0)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,46 +1,92 @@
 #!/bin/bash
 
-echo "
- ____  _      ____  ____  _____    _      _  ____  ____  ____  ____ 
-/ ___\/ \__/|/  _ \/  __\/__ __\  / \__/|/ \/  __\/  __\/  _ \/  __\
-|    \| |\/||| / \||  \/|  / \    | |\/||| ||  \/||  \/|| / \||  \/|
-\___ || |  ||| |-|||    /  | |    | |  ||| ||    /|    /| \_/||    /
-\____/\_/  \|\_/ \|\_/\_\  \_/    \_/  \|\_/\_/\_\\_/\_\\____/\_/\_\
-                                                                    
-                                                                    "
+# Supported versions of node: v4.x, v5.x
+NODE_VERSION="v4.*\|v5.*"
 
-echo "Installing Smart Mirror Dependencies........!"
+# Ensure we are not using sudo (this could cause bad things to happen)
+if [ "$(whoami)" == "root" ];
+then
+	echo "Sorry, this script should not be run with 'sudo'."
+	exit 1
+fi
 
-# You'll also need to install Node (v4.0.0+) which now comes bundled with npm.
-echo "Installing NodeJS!"
-wget https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv7l.tar.gz
-tar -xvf node-v4.0.0-linux-armv7l.tar.gz 
-cd node-v4.0.0-linux-armv7l
+cat << "EOF"
+ ________  _____ ______   ________  ________  _________         
+|\   ____\|\   _ \  _   \|\   __  \|\   __  \|\___   ___\       
+\ \  \___|\ \  \\\__\ \  \ \  \|\  \ \  \|\  \|___ \  \_|       
+ \ \_____  \ \  \\|__| \  \ \   __  \ \   _  _\   \ \  \        
+  \|____|\  \ \  \    \ \  \ \  \ \  \ \  \\  \|   \ \  \       
+    ____\_\  \ \__\    \ \__\ \__\ \__\ \__\\ _\    \ \__\      
+   |\_________\|__|     \|__|\|__|\|__|\|__|\|__|    \|__|      
+   \|_________|                                                 
+                                                                
+ _____ ______   ___  ________  ________  ________  ________     
+|\   _ \  _   \|\  \|\   __  \|\   __  \|\   __  \|\   __  \    
+\ \  \\\__\ \  \ \  \ \  \|\  \ \  \|\  \ \  \|\  \ \  \|\  \   
+ \ \  \\|__| \  \ \  \ \   _  _\ \   _  _\ \  \\\  \ \   _  _\  
+  \ \  \    \ \  \ \  \ \  \\  \\ \  \\  \\ \  \\\  \ \  \\  \| 
+   \ \__\    \ \__\ \__\ \__\\ _\\ \__\\ _\\ \_______\ \__\\ _\ 
+    \|__|     \|__|\|__|\|__|\|__|\|__|\|__|\|_______|\|__|\|__|
 
-# Copy to /usr/local
-echo "Copying NodeJS to /usr/local/"
-sudo cp -R * /usr/local/
+EOF
+
+echo "This script will install the smart-mirror and it's dependencies."
+
+
+read -r -p "Would you like to continue? [y/N] " response
+if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+then
+    echo "Excellent!"
+else
+    exit 1
+fi
+
+echo "Checking for node"
+node --version | grep ${NODE_VERSION}
+if [[ $? != 0 ]] ;
+then
+    # Install Node
+    echo "$(tput setaf 9)Downloading Node$(tput sgr0)"
+    wget https://nodejs.org/dist/v4.0.0/node-v4.0.0-linux-armv7l.tar.gz
+    tar -xvf node-v4.0.0-linux-armv7l.tar.gz 
+    cd node-v4.0.0-linux-armv7l
+    
+    # Copy to /usr/local
+    echo "$(tput setaf 9)Installing Node$(tput sgr0)"
+    sudo cp -R * /usr/local/
+    
+    # Clean up after ourselvs
+    cd ..
+    rm node-v4.0.0-linux-armv7l.tar.gz
+    rm -R node-v4.0.0-linux-armv7l
+    echo "$(tput setaf 10)Node is now installed!$(tput sgr0)"
+else
+    echo "$(tput setaf 10)node is already installed, great job!$(tput sgr0)"
+fi
 
 # Getting the code
 
 # Next up you'll want to clone this repository into your user's home folder on your Pi:
 
-echo "Cloning Git Repo"
+echo "$(tput setaf 9)Cloning Git Repo$(tput sgr0)"
 cd ~
 git clone https://github.com/evancohen/smart-mirror.git
+echo "$(tput setaf 10)smart-mirror code is now downloaded$(tput sgr0)"
 
 cd smart-mirror
 
-echo "Renaming Config File"
+echo "$(tput setaf 9)Creating Mirror Config$(tput sgr0)"
 cp config.example.js config.js
 
 
 #Hide the mouse when inactive
-echo "Installing unclutter"
+echo "$(tput setaf 9)Installing unclutter$(tput sgr0)"
 sudo apt-get install unclutter
 
-echo "Installing Ndde Packages"
+echo "$(tput setaf 9)Installing smart-mirror dependencies...$(tput sgr0)"
+echo "$(tput setaf 11)This may take a bit$(tput sgr0)"
 npm install
+echo "$(tput setaf 10)The smart-mirror is now installed!$(tput sgr0)"
 
 # Launching Smart Mirror App
 npm start

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,14 +80,14 @@ fi
 
 # Getting the code
 printf "\n$(tput setaf 12)Cloning Git Repo$(tput sgr0)\n"
-cd /home/$LOGNAME
-sudo -u $LOGNAME git clone https://github.com/evancohen/smart-mirror.git
+cd /home/$SUDO_USER
+sudo -u $SUDO_USER git clone https://github.com/evancohen/smart-mirror.git
 printf "\n$(tput setaf 10)smart-mirror code is now downloaded$(tput sgr0)\n"
 
 cd smart-mirror
 
 printf "$(tput setaf 12)generating config template$(tput sgr0)\n"
-sudo -u $LOGNAME cp config.example.js config.js
+sudo -u $SUDO_USER cp config.example.js config.js
 
 # Install package to hide the mouse when inactive
 printf "\n$(tput setaf 12)Installing unclutter$(tput sgr0)\n"
@@ -101,7 +101,7 @@ unclutter -idle 0.1 -root' /etc/xdg/lxsession/LXDE/autostart
 
 printf "\n$(tput setaf 12)Installing smart-mirror dependencies...$(tput sgr0)\n"
 printf "$(tput setaf 11)This may take a while. Go grab a beer :)$(tput sgr0)\n"
-sudo -u $LOGNAME npm install
+sudo -u $SUDO_USER npm install
 
 # The mirror is now installed, yay!
 cat << "EOF"


### PR DESCRIPTION
Users can now pass in multiple trips into the config. This is a BREAKING CHANGE.

@shoaibuddin sent a PR (#202) which got me thinking about ways the installation process could be easier. I reworked the script he wrote to be a bit more robust + user friendly. The script (which is a one-off) takes care of:
- installing node (if you don't have it already)
- rotating the screen (requires reboot)
- removing the mouse when inactive
- cloning the repo
- installing dependencies