### PR TITLE
Keep reminders between instances

### DIFF
--- a/js/services/reminder.js
+++ b/js/services/reminder.js
@@ -2,6 +2,8 @@
     'use strict';
 
     function ReminderService($translate){
+        // Storage variable
+        const storage = require('electron-json-storage');
         // Service variable
         var service = {};
         // Flag to check if reminders list is empty
@@ -9,12 +11,24 @@
         // Need to use the callback function because when the service is initialize,
         // the translation service is not set up.
         $translate('reminders.empty').then(function (translation) {
-            service.reminders= [translation];
+            service.reminders = [translation];
+        });
+        // Check if reminder storage already exists
+        storage.has('sm-reminder', function(error, hasKey) {
+            if (error) throw error;
+            if (hasKey) {
+                // Flag to check if reminders list is empty
+                service.empty = false;
+                storage.get('sm-reminder', function(error, data) {
+                    if (error) throw error;
+                    service.reminders = data.reminders;
+                });
+            }
         });
 
         // Insert a new task in the reminder list.
-    	service.insertReminder = function(remindMe){
-    		if (service.empty){
+        service.insertReminder = function(remindMe){
+		    if (service.empty){
                 // If the list is empty, clear the reminders array because it contains the default empty task
                 service.reminders = [];
                 // Pass the flag to false
@@ -22,23 +36,28 @@
             }
             // Push the new task to reminders list
             service.reminders.push(remindMe);
+            storage.set('sm-reminder', { reminders: service.reminders }, function(error) {
+                if (error) throw error;
+            });
             console.debug(service.reminders);
             return service.reminders;
-    	}
+        }
 
         // Clear the reminders list and set the empty flag to true
-    	service.clearReminder = function(){
-    		service.reminders = [$translate.instant('reminders.empty')];
-    		service.empty = true;
-    		return service.reminders;
-    	}
+        service.clearReminder = function(){
+            service.reminders = [$translate.instant('reminders.empty')];
+            service.empty = true;
+            storage.set('sm-reminder', { reminders: service.reminders }, function(error) {
+                if (error) throw error;
+            });
+            return service.reminders;
+        }
 
         // Return the reminders list
-    	service.getReminders = function(){
-    		return service.reminders;
-    	}
-
-    	return service;
+        service.getReminders = function(){
+            return service.reminders;
+        }
+        return service;
     }
 
 	angular.module('SmartMirror')

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "express": "^4.13.4",
     "fitbit-oauth2": "0.0.1",
-    "fs": "0.0.2"
+    "fs": "0.0.2",
+    "electron-json-storage": "2.0.0"
   }
 }


### PR DESCRIPTION
Add electron-json-storage to keep reminders between different instances. You can now add reminders, close mirror, open mirror and see all reminders from the previous session.