### PR TITLE
Updating electron to v1.0.0

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,35 +1,22 @@
 /* global __dirname */
 /* global process */
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
-
-// Report crashes to our server. Disabled for now.
-//require('crash-reporter').start();
-
-// Prevent the computer from going to sleep
-const powerSaveBlocker = require('electron').powerSaveBlocker;
+const electron = require('electron')
+// Module to control application life.
+const app = electron.app
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow
+// Prevent the monitor from going to sleep.
+const powerSaveBlocker = electron.powerSaveBlocker;
 powerSaveBlocker.start('prevent-display-sleep');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-var mainWindow = null;
+let mainWindow
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function() {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform != 'darwin') {
-    app.quit();
-  }
-});
-
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-app.on('ready', function() {
-
-
-  // Put the app on a secondary display if availalbe
-  var atomScreen = require('screen');
+function createWindow () {
+  
+  // Get the displays and render the mirror on a secondary screen if it exists
+  var atomScreen = electron.screen;
   var displays = atomScreen.getAllDisplays();
   var externalDisplay = null;
   for (var i in displays) {
@@ -44,24 +31,45 @@ app.on('ready', function() {
     browserWindowOptions.x = externalDisplay.bounds.x + 50;
     browserWindowOptions.y = externalDisplay.bounds.y + 50
   }
-
+  
   // Create the browser window.
-  mainWindow = new BrowserWindow(browserWindowOptions);
+  mainWindow = new BrowserWindow(browserWindowOptions)
 
   // and load the index.html of the app.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html')
 
   // Open the DevTools if run with "npm start dev"
   if(process.argv[2] == "dev"){
     mainWindow.webContents.openDevTools();
   }
 
-
   // Emitted when the window is closed.
-  mainWindow.on('closed', function() {
+  mainWindow.on('closed', function () {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    mainWindow = null;
-  });
-});
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "install": "^0.7.3",
     "angular-i18n": "^1.5.5",
     "wiredep-cli": "^0.1.0",
-    "electron-prebuilt": "^0.37.8",
+    "electron-prebuilt": "^1.0.0",
     "npm": "^3.8.8",
     "bower": "^1.7.9"
   },


### PR DESCRIPTION
Jumping on the party wagon because [Electron](http://electron.atom.io/) has [just reached v1.0](https://github.com/blog/2167-electron-1-0-is-here) 🎈 

**[electron-prebuilt](https://github.com/electron-userland/electron-prebuilt)** is now using v1.0.0: electron-userland/electron-prebuilt@398ffef50f98a9350cf8742bf87b30a7a29d2ba6

**Breaking Changes**
None! But you will have to run `npm install` after updating in order to download the latest [electron-prebuilt](https://github.com/electron-userland/electron-prebuilt) binary.