### PR TITLE
Making all config values optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
           <div class="weather-today">
             <span class="icon dimmed wi {{currentForcast.wi}}"></span>
             <canvas id="icon_weather_current" width="90" height="70"></canvas>
-            <span class="tempreture">{{currentForcast.temperature}}&deg;</span>
+            <span class="tempreture" ng-show="currentForcast.temperature">{{currentForcast.temperature}}&deg;</span>
           </div>
           <div class="weather-week-descriptor">
             <span>{{hourlyForcast.summary}}</span>

--- a/index.html
+++ b/index.html
@@ -66,26 +66,26 @@
       <div class="top-right">
         <div class="weather">
           <div class="weather-today">
-            <span class="icon dimmed wi {{currentForcast.wi}}"></span>
+            <span class="icon dimmed wi {{currentForecast.wi}}"></span>
             <canvas id="icon_weather_current" width="90" height="70"></canvas>
-            <span class="tempreture" ng-show="currentForcast.temperature">{{currentForcast.temperature}}&deg;</span>
+            <span class="tempreture" ng-show="currentForecast.temperature">{{currentForecast.temperature}}&deg;</span>
           </div>
           <div class="weather-week-descriptor">
-            <span>{{hourlyForcast.summary}}</span>
-            <span>{{weeklyForcast.summary}}</span>
+            <span>{{hourlyForecast.summary}}</span>
+            <span>{{weeklyForecast.summary}}</span>
           </div>
-          <div class="weather-week" ng-repeat="forcast in weeklyForcast.data" ng-if="$index > 0">
+          <div class="weather-week" ng-repeat="forecast in weeklyForecast.data" ng-if="$index > 0">
             <div class="weather-week-day">
-              <span class="day light-grey">{{forcast.day}}</span>
-              <canvas id="icon_weather_{{forcast.counter}}" width="33" height="25"></canvas>
-              <span class="icon-small dimmed wi wi-fw {{forcast.wi}}"></span>
-              <span class="tempreture tempreture-min">{{forcast.temperatureMin}}&deg;</span>
-              <span class="tempreture tempreture-max">{{forcast.temperatureMax}}&deg;</span>
+              <span class="day light-grey">{{forecast.day}}</span>
+              <canvas id="icon_weather_{{forecast.counter}}" width="33" height="25"></canvas>
+              <span class="icon-small dimmed wi wi-fw {{forecast.wi}}"></span>
+              <span class="tempreture tempreture-min">{{forecast.temperatureMin}}&deg;</span>
+              <span class="tempreture tempreture-max">{{forecast.temperatureMax}}&deg;</span>
             </div>
           </div>
           <!-- Workaround: -->
-          <div style="display: none;" ng-repeat="forcast in weeklyForcast.data" ng-if="$index > 0">
-            <span ng-init="iconLoad('icon_weather_'+forcast.counter, forcast.iconAnimation)"></span>
+          <div style="display: none;" ng-repeat="forecast in weeklyForecast.data" ng-if="$index > 0">
+            <span ng-init="iconLoad('icon_weather_'+forecast.counter, forecast.iconAnimation)"></span>
           </div>
         </div>
         <div class="traffic" ng-repeat="traffic in trips">

--- a/js/app.js
+++ b/js/app.js
@@ -1,11 +1,13 @@
 // Bootstrap Angular
 (function(angular) {
     'use strict';
-
+    
+    var language = (typeof config.language != 'undefined')?config.language.substring(0, 2).toLowerCase(): 'en';
+    
     angular.module('SmartMirror', ['ngAnimate', 'tmh.dynamicLocale', 'pascalprecht.translate'])
         .config(function(tmhDynamicLocaleProvider) {
-            var locale = config.language.toLowerCase();
-            tmhDynamicLocaleProvider.localeLocationPattern('bower_components/angular-i18n/angular-locale_' + locale + '.js');
+            console.log(config)
+            tmhDynamicLocaleProvider.localeLocationPattern('bower_components/angular-i18n/angular-locale_' + language + '.js');
         })
         
         .config(['$translateProvider', function ($translateProvider) {
@@ -19,7 +21,7 @@
             // Avoiding the duplicity of the locale for the default language, xx-YY -> xx
             // We are considering only the language
             // Please refer https://github.com/evancohen/smart-mirror/pull/179 for further discussion
-            var language = config.language.substring(0, 2);
+            var language = (typeof config.language != 'undefined')?config.language.substring(0, 2): 'en';
             $translateProvider.preferredLanguage(language);
         }])
         

--- a/js/controller.js
+++ b/js/controller.js
@@ -35,9 +35,7 @@
         }
 
         //set lang
-        $scope.locale = config.language;
-        tmhDynamicLocale.set(config.language.toLowerCase());
-        moment.locale(config.language);
+        moment.locale((typeof config.language != 'undefined')?config.language.substring(0, 2).toLowerCase(): 'en');
         console.log('moment local', moment.locale());
 
         //Update the time
@@ -118,7 +116,7 @@
             $interval(refreshMirrorData, 1500000);
 
             var greetingUpdater = function () {
-                if(!Array.isArray(config.greeting) && typeof config.greeting.midday != 'undefined') {
+                if(typeof config.greeting != 'undefined' && !Array.isArray(config.greeting) && typeof config.greeting.midday != 'undefined') {
                     var hour = moment().hour();
                     var greetingTime = "midday";
 
@@ -149,8 +147,10 @@
                 });
             };
 
-            refreshTrafficData();
-            $interval(refreshTrafficData, config.traffic.reload_interval * 60000);
+            if(typeof config.traffic != 'undefined'){
+                refreshTrafficData();
+                $interval(refreshTrafficData, config.traffic.reload_interval * 60000);    
+            }
 
             var refreshComic = function () {
                 console.log("Refreshing comic");

--- a/js/controller.js
+++ b/js/controller.js
@@ -68,15 +68,15 @@
                 GeolocationService.getLocation({enableHighAccuracy: true}).then(function(geoposition){
                     console.log("Geoposition", geoposition);
                     WeatherService.init(geoposition).then(function(){
-                        $scope.currentForcast = WeatherService.currentForcast();
-                        $scope.weeklyForcast = WeatherService.weeklyForcast();
-                        $scope.hourlyForcast = WeatherService.hourlyForcast();
-                        console.log("Current", $scope.currentForcast);
-                        console.log("Weekly", $scope.weeklyForcast);
-                        console.log("Hourly", $scope.hourlyForcast);
+                        $scope.currentForecast = WeatherService.currentForecast();
+                        $scope.weeklyForecast = WeatherService.weeklyForecast();
+                        $scope.hourlyForecast = WeatherService.hourlyForecast();
+                        console.log("Current", $scope.currentForecast);
+                        console.log("Weekly", $scope.weeklyForecast);
+                        console.log("Hourly", $scope.hourlyForecast);
 
                         var skycons = new Skycons({"color": "#aaa"});
-                        skycons.add("icon_weather_current", $scope.currentForcast.iconAnimation);
+                        skycons.add("icon_weather_current", $scope.currentForecast.iconAnimation);
 
                         skycons.play();
 

--- a/js/services/calendar.js
+++ b/js/services/calendar.js
@@ -12,7 +12,7 @@
       service.events = [];
       if(typeof config.calendar != 'undefined' && typeof config.calendar.icals != 'undefined'){
         loadFile(config.calendar.icals).then(function(){
-          deferred.reolve();
+          deferred.resolve();
         });
       } else {
         deferred.reject("No iCals defined");

--- a/js/services/calendar.js
+++ b/js/services/calendar.js
@@ -7,8 +7,18 @@
     service.events = [];
 
     service.getCalendarEvents = function() {
+      var deferred = $q.defer();
+      
       service.events = [];
-      return loadFile(config.calendar.icals);
+      if(typeof config.calendar != 'undefined' && typeof config.calendar.icals != 'undefined'){
+        loadFile(config.calendar.icals).then(function(){
+          deferred.reolve();
+        });
+      } else {
+        deferred.reject("No iCals defined");
+      }
+        
+      return deferred.promise;
     }
 
     var loadFile = function(urls) {

--- a/js/services/soundcloud.js
+++ b/js/services/soundcloud.js
@@ -10,9 +10,12 @@
 		service.scResponse = null;
 
 		service.init = function() {
-			SC.initialize({
-				client_id: config.soundcloud.key
-			});
+      // If the soundcloud key is defined and not empty
+      if(typeof config.soundcloud != 'undefined' && config.soundcloud.length()){
+          SC.initialize({
+            client_id: config.soundcloud.key
+          });
+      }
 		}
 
         //Returns the soundcloud search results for the given query

--- a/js/services/soundcloud.js
+++ b/js/services/soundcloud.js
@@ -11,7 +11,7 @@
 
 		service.init = function() {
       // If the soundcloud key is defined and not empty
-      if(typeof config.soundcloud != 'undefined' && config.soundcloud.length()){
+      if(typeof config.soundcloud != 'undefined' && config.soundcloud.length) {
           SC.initialize({
             client_id: config.soundcloud.key
           });

--- a/js/services/traffic.js
+++ b/js/services/traffic.js
@@ -9,16 +9,20 @@
             var deferred = $q.defer();
             var promises = [];
 
-            angular.forEach(config.traffic.trips, function(trip) {
-              if (trip.hasOwnProperty('startTime') && TimeboxService.shouldDisplay(trip.startTime, trip.endTime)
-                || !trip.hasOwnProperty('startTime')) {
-                promises.push(getTripDuration(trip));
-              }
-            });
+            if(typeof config.traffic != 'undefined' && config.traffic.trips != 'undefined'){                
+                angular.forEach(config.traffic.trips, function(trip) {
+                    if (trip.hasOwnProperty('startTime') && TimeboxService.shouldDisplay(trip.startTime, trip.endTime)
+                        || !trip.hasOwnProperty('startTime')) {
+                        promises.push(getTripDuration(trip));
+                    }
+                });
 
-            $q.all(promises).then(function(data) {
-                deferred.resolve(data)
-            });
+                $q.all(promises).then(function(data) {
+                    deferred.resolve(data)
+                });
+            } else {
+                deferred.reject;
+            }
 
             return deferred.promise;
         };

--- a/js/services/weather.js
+++ b/js/services/weather.js
@@ -17,7 +17,7 @@
         };
 
         //Returns the current forecast along with high and low tempratures for the current day 
-        service.currentforecast = function() {
+        service.currentForecast = function() {
             if(service.forecast === null){
                 return null;
             }
@@ -28,7 +28,7 @@
             return service.forecast.data.currently;
         }
 
-        service.weeklyforecast = function(){
+        service.weeklyForecast = function(){
             if(service.forecast === null){
                 return null;
             }
@@ -44,7 +44,7 @@
             return service.forecast.data.daily;
         }
 		
-        service.hourlyforecast = function() {
+        service.hourlyForecast = function() {
             if(service.forecast === null){
                 return null;
             }

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,6 +1,6 @@
 {
     "home" : {
-      "commands" : "Sag' \"Was kann ich sagen?\" um eine Liste von Befehlen zu sehen..."
+      "commands" : "Sag: \"Was kann ich sagen?\" um eine Liste von Befehlen zu sehen..."
     },
     "traffic" : {
         "time_to" : "Zeit bis {{name}}: "

--- a/main.js
+++ b/main.js
@@ -73,6 +73,9 @@ function createWindow () {
 }
 
 // Get keyword spotting config
+if(typeof config.speech == 'undefined'){
+  config.speech = {}
+}
 var modelFile = config.speech.model || "smart_mirror.pmdl"
 var kwsSensitivity = config.speech.sensitivity || 0.5
 


### PR DESCRIPTION
I used a `config.js` file with the following to test:
``` javascript
var config = {};
if (typeof module !== 'undefined') {module.exports = config;}
```
The mirror will now load correctly with this config. This means that specific services without configuration options will no longer cause the mirror to error out.

I've also written some much more extensive documentation around the actual configuration of the mirror on the documentation site here: http://docs.smart-mirror.io/docs/configure_the_mirror.html

+ A few other random fixes

@kurtdb can you review?