### PR TITLE
Fix issue #270 + stop listening command

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -400,6 +400,13 @@
               }
             });
 
+            // Stop listening
+            addCommand('stop_listening', function() {
+                console.debug("Stop listening.");
+                SpeechService.abort();
+                $scope.focus = "default";
+            });
+
             var resetCommandTimeout;
             //Register callbacks for Annyang and the Keyword Spotter
             SpeechService.registerCallbacks({

--- a/js/services/speech.js
+++ b/js/services/speech.js
@@ -7,6 +7,8 @@ const {ipcRenderer} = require('electron');
         var service = {};
    
         service.init = function() {
+            // Set annyang language defined in the config file
+            annyang.setLanguage(config.language);
             // Inicialize Keyword Spotter IPC
             ipcRenderer.on('keyword-spotted', (event, arg) => {
                 annyang.start();

--- a/locales/de.json
+++ b/locales/de.json
@@ -184,6 +184,11 @@
             "text": "Schalte das (state) Licht (action)",
             "voice": "(Schalte) (das) :state (die) Licht(er) *action",
             "description": "(Schalte) (das) :state (die) Licht(er) *action"
+        },
+        "stop_listening": {
+            "text": "(Danke) (Stopp) (Ok)",
+            "voice": "(Danke) (Stopp) (Ok)",
+            "description": "(Danke) (Stopp) (Ok)"
         }
     }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -184,6 +184,11 @@
             "text": "Turn the (state) light (action)",
             "voice": "(turn) (the) :state (the) light(s) *action",
             "description": "(turn) (the) :state (the) light(s) *action"
+        },
+        "stop_listening": {
+            "text": "(Thank you) (Stop) (Ok)",
+            "voice": "(Thank you) (Stop) (Ok)",
+            "description": "(Thank you) (Stop) (Ok)"
         }
     }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -184,6 +184,11 @@
             "text": "[estado] las luces a [acción]",
             "voice": ":state las luces a *action",
             "description": "Cambia el estado de las luces"
+        },
+        "stop_listening": {
+            "text": "(Gracias) (bueno)",
+            "voice": "(Gracias) (bueno)",
+            "description": "(Gracias) (bueno)"
         }
     }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -184,6 +184,11 @@
             "text": "(Allume|Éteins) (la|les) lumières (action)",
             "voice": ":state (les) (la) lumière(s) (*action)",
             "description": ":state (les) (la) lumière(s) (*action)"
+        },
+        "stop_listening": {
+            "text": "(Merci) (Stop) (Ok)",
+            "voice": "(Merci) (Stop) (Ok)",
+            "description": "(Merci) (Stop) (Ok)"
         }
     }
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -184,6 +184,11 @@
             "text": "불 (흰/빨간/파란)색으로 (켜/꺼)줘",
             "voice": "불 :state *action (해)줘",
             "description": "불 :state *action (해)줘"
+        },
+        "stop_listening": {
+            "text": "(고맙습니다) (정지) (확인)",
+            "voice": "(고맙습니다) (정지) (확인)",
+            "description": "(고맙습니다) (정지) (확인)"
         }
     }
 }


### PR DESCRIPTION
I restore the setLanguage for annyang and add a stop listening command for users who used the continuous snowboy functionality. It's useful when you want to shut the annyang service instantly.