### PR TITLE
[FEATURE] Add minutely summary to weather week descriptor

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
             <span class="temperature" ng-show="currentForecast.temperature">{{currentForecast.temperature}}&deg;</span>
           </div>
           <div class="weather-week-descriptor">
+            <span>{{minutelyForecast.summary}}</span>
             <span>{{hourlyForecast.summary}}</span>
             <span>{{weeklyForecast.summary}}</span>
           </div>

--- a/js/controller.js
+++ b/js/controller.js
@@ -73,9 +73,11 @@
                         $scope.currentForecast = WeatherService.currentForecast();
                         $scope.weeklyForecast = WeatherService.weeklyForecast();
                         $scope.hourlyForecast = WeatherService.hourlyForecast();
+                        $scope.minutelyForecast = WeatherService.minutelyForecast();
                         console.log("Current", $scope.currentForecast);
                         console.log("Weekly", $scope.weeklyForecast);
                         console.log("Hourly", $scope.hourlyForecast);
+                        console.log("Minutely", $scope.minutelyForecast);
 
                         var skycons = new Skycons({"color": "#aaa"});
                         skycons.add("icon_weather_current", $scope.currentForecast.iconAnimation);

--- a/js/services/weather.js
+++ b/js/services/weather.js
@@ -16,7 +16,14 @@
                 });
         };
 
-        //Returns the current forecast along with high and low tempratures for the current day 
+        service.minutelyForecast = function(){
+            if(service.forecast === null){
+                return null;
+            }
+            return service.forecast.data.minutely;
+        }
+
+        //Returns the current forecast along with high and low tempratures for the current day
         service.currentForecast = function() {
             if(service.forecast === null){
                 return null;


### PR DESCRIPTION
<img width="253" alt="screen shot 2016-06-23 at 8 54 06 pm" src="https://cloud.githubusercontent.com/assets/1940294/16326547/e0084978-3984-11e6-83f5-b15d4cd14eae.png">

@evancohen I added this field to my personal fork of the repo, and have really found it useful in practice. The forecast.io API summaries really work well together: this adds the summary for the next 60 minutes, which gives a nice immediate context ahead of the 12-24 hour summary and the 7 day summary.

