### PR TITLE
[FEATURE] Group events by day for simpler display.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -113,16 +113,26 @@ ul.calendar {
 .calendar span {
   display: inline-block; }
   .calendar span.day {
+  .calendar .day {
+    display: none;
     font-weight: bold;
+    position: absolute;
     width: 128px;
     vertical-align: top; }
   .calendar span.summary {
+    margin-left: 150px;
     max-width: 400px; }
 .calendar .event-details .details {
   font-size: 12px;
-  padding-left: 135px;
+  padding-left: 150px;
   font-family: 'Open Sans', sans-serif;
   font-weight: lighter; }
+.day-marker {
+  margin-top: 30px;
+}
+.day-marker .day {
+  display: block;
+}
 
 .weather {
   margin-left: auto;

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         <div class="date grey">{{date.format('dddd')}}, {{date.format('LL')}}</div>
         <div class="time">{{date.format('LT')}}</div>
         <ul class="calendar fade" ng-show="focus == 'default'">
-            <li class="event" ng-repeat="event in calendar">
+            <li class="event" ng-repeat="event in calendar" ng-class="(calendar[$index - 1].start.format('MD') != event.start.format('MD')) ? 'day-marker' : ''">
                 <div class="event-details">
                     <span class="day">{{event.start.format('dddd') | uppercase}}</span>
                     <span class="summary">{{event.SUMMARY}}</span>


### PR DESCRIPTION
Listing the day name repetitively is a bit cluttered for my tastes. This PR only shows the day name for the first event of the day.

Before:
<img width="438" alt="screen shot 2016-06-28 at 7 39 29 pm" src="https://cloud.githubusercontent.com/assets/1940294/16438714/50dff2fc-3d6f-11e6-843e-f85f0c7a822e.png">

After:
<img width="441" alt="screen shot 2016-06-28 at 8 29 47 pm" src="https://cloud.githubusercontent.com/assets/1940294/16438719/54ee0104-3d6f-11e6-8fff-527461dc5020.png">
