### PR TITLE
[FEATURE] Optionally show calendar names above events

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -80,7 +80,8 @@ var config = {
     calendar: {
       icals : [], // Be sure to wrap your URLs in quotes
       maxResults: 9, // Number of calender events to display (Defaults is 9)
-      maxDays: 365 // Number of days to display (Default is one year)
+      maxDays: 365, // Number of days to display (Default is one year)
+      showCalendarNames: false // Show calendar names above events
     },
     // Giphy
     giphy: {

--- a/css/main.css
+++ b/css/main.css
@@ -163,6 +163,14 @@ ul.calendar {
     font-weight: lighter; 
 }
 
+.calendar-name {
+  display: none;
+}
+
+.show-calendar-names .calendar-name {
+  display: block;
+}
+
 .day-marker {
 	margin-top: 30px;
 }

--- a/index.html
+++ b/index.html
@@ -56,10 +56,11 @@
       <div class="top-left">
         <div class="date grey">{{date.format('dddd')}}, {{date.format('LL')}}</div>
         <div class="time">{{date.format('LT')}}</div>
-        <ul class="calendar fade" ng-show="focus == 'default'">
+        <ul class="calendar fade" ng-show="focus == 'default'" ng-class="config.calendar.showCalendarNames ? 'show-calendar-names' : ''">
             <li class="event" ng-repeat="event in calendar" ng-class="(calendar[$index - 1].start.format('MD') != event.start.format('MD')) ? 'day-marker' : ''">
                 <div class="event-details">
                     <span class="day">{{event.start.calendar() | uppercase}}</span>
+                    <div class="details calendar-name">{{event.calendarName}}</div>
                     <span class="summary">{{event.SUMMARY}}</span>
                     <div class="details">{{event.start.format('LLL')}}</div>
                 </div>

--- a/js/controller.js
+++ b/js/controller.js
@@ -33,6 +33,8 @@
         $scope.layoutName = 'main';
 
         $scope.fitbitEnabled = false;
+        $scope.config = config;
+
         if (typeof config.fitbit !== 'undefined') {
             $scope.fitbitEnabled = true;
         }

--- a/js/services/calendar.js
+++ b/js/services/calendar.js
@@ -60,6 +60,12 @@
       var cur_event = null;
       for (var i = 0; i < cal_array.length; i++) {
         var ln = cal_array[i];
+
+        // Extract calendar name
+        if (ln.startsWith('X-WR-CALNAME')) {
+          var calendarName = ln.split(':')[1];
+        }
+
         //If we encounted a new Event, create a blank event object + set in event options.
         if (!in_event && ln == 'BEGIN:VEVENT') {
           var in_event = true;
@@ -68,6 +74,7 @@
         //If we encounter end event, complete the object and add it to our events array then clear it for reuse.
         if (in_event && ln == 'END:VEVENT') {
           in_event = false;
+          cur_event.calendarName = calendarName;
           if(!contains(events, cur_event)) {
             events.push(cur_event);
           }
@@ -127,6 +134,7 @@
       				var startDate = moment(dt);
       				var endDate = moment(dt);
               endDate.add(event_duration, 'minutes');
+              recuring_event.calendarName = calendarName;
               recuring_event.start = startDate;
               recuring_event.end = endDate;
               if(!contains(events, recuring_event)) {


### PR DESCRIPTION
When combining multiple calendars, it is nice to have the option to know which calendar an event is from. This feature is turned off by default.

<img width="479" alt="screen shot 2016-07-01 at 12 49 09 pm" src="https://cloud.githubusercontent.com/assets/1940294/16531566/3d8d9098-3f8a-11e6-9b4f-57ef3725dee0.png">
