### PR TITLE
[FEATURE] Use Today/Tomorrow/Day name for calendar entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         <ul class="calendar fade" ng-show="focus == 'default'">
             <li class="event" ng-repeat="event in calendar" ng-class="(calendar[$index - 1].start.format('MD') != event.start.format('MD')) ? 'day-marker' : ''">
                 <div class="event-details">
-                    <span class="day">{{event.start.format('dddd') | uppercase}}</span>
+                    <span class="day">{{event.start.calendar() | uppercase}}</span>
                     <span class="summary">{{event.SUMMARY}}</span>
                     <div class="details">{{event.start.format('LLL')}}</div>
                 </div>

--- a/js/controller.js
+++ b/js/controller.js
@@ -38,7 +38,17 @@
         }
 
         //set lang
-        moment.locale((typeof config.language !== 'undefined')?config.language.substring(0, 2).toLowerCase(): 'en');
+        moment.locale(
+          (typeof config.language !== 'undefined')?config.language.substring(0, 2).toLowerCase(): 'en',
+          {
+            calendar : {
+              sameDay : '[Today]',
+              nextDay : '[Tomorrow]',
+              nextWeek : 'dddd'
+            }
+          }
+        );
+
         console.log('moment local', moment.locale());
 
         //Update the time


### PR DESCRIPTION
[Resolves #316]

<img width="468" alt="screen shot 2016-07-01 at 12 59 35 pm" src="https://cloud.githubusercontent.com/assets/1940294/16531909/fc4e206e-3f8b-11e6-94d4-118a38e77f1a.png">
