### PR TITLE
Update Gifly API key to reflect fixed api

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -78,7 +78,7 @@ var config = {
     },
     // Giphy
     giphy: {
-      key : "" // Your Gliphy API key
+      key : "dc6zaTOxFJmzC" // Your Gliphy API key
     },
     // YouTube
     youtube: {


### PR DESCRIPTION
since the Gifly API uses the same key for all developers why not include it in the config.example.js file?