### PR TITLE
Remove fs from package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "express": "^4.13.4",
     "fitbit-oauth2": "0.0.1",
-    "fs": "0.0.2",
     "hyperion-client": "1.0.3",
     "electron-json-storage": "2.0.0"
   }


### PR DESCRIPTION
You may not be aware of the recent chaos around the 'fs' module, but believe me you don't want it in here. In short, all it does is print `I am fs`. You probably installed it looking for `require('fs')` which is a native module and not an NPM one.

See http://status.npmjs.org/incidents/dw8cr1lwxkcr