### PR TITLE
Added tvshows service

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -121,6 +121,9 @@ var config = {
         key: "", // Your last.fm api key
         user: "", // Your last.fm username
         refreshInterval: 0.6 // Number of minutes between checks for playing track
+    },
+    tvshows: {
+      shows : ["Game of Thrones", "The Walking Dead"],  // TV Shows list - e.g. ["Mad Men", "The Walking Dead", "Game of Thrones"]
     }
 };
 

--- a/config.example.js
+++ b/config.example.js
@@ -123,7 +123,8 @@ var config = {
         refreshInterval: 0.6 // Number of minutes between checks for playing track
     },
     tvshows: {
-      shows : ["Game of Thrones", "The Walking Dead"],  // TV Shows list - e.g. ["Mad Men", "The Walking Dead", "Game of Thrones"]
+        shows : ["Game of Thrones", "The Walking Dead"],  // TV Shows list - e.g. ["Mad Men", "The Walking Dead", "Game of Thrones"]
+        refreshInterval: 1440 // Number of minutes between checking for new episodes
     }
 };
 

--- a/css/main.css
+++ b/css/main.css
@@ -263,7 +263,7 @@ ul.calendar {
     margin-right: 5px;
 }
 
-.traffic-information, .stock-information {
+.traffic-information, .stock-information, .tv-information {
     text-align: right;
     margin-top: 10px;
     margin-right: 10px;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     <script src="js/services/fitbit.js"></script>
     <script src="js/services/reminder.js"></script>
     <script src="js/services/rss.js"></script>
+    <script src="js/services/tvshows.js"></script>
     <script src="js/services/autosleep.js"></script>
     <script src="js/services/stock.js"></script>
     <script src="js/services/scrobbler.js"></script>
@@ -112,6 +113,12 @@
           <div class="stock-information" ng-repeat="quote in stock">
             <span><i class="fa fa-rss fade" style="margin-right: 5px";></i></span>
             <span fade ng-bind="quote.Name"></span>: $<span fade ng-bind="quote.LastTradePriceOnly  | number : 3"></span><span ng-bind="quote.Change"></span>
+          </div>
+        </div>
+        <div class="tvshows">
+          <div class="tv-information time-to" ng-repeat="show in tvshows">
+            <span><i class="fa fa-rss fade" style="margin-right: 5px";></i></span>
+            <span fade><span style="font-weight: bold" ng-bind="show.data.episode.show.title"></span> – <span ng-bind="show.data.episode.release_date"></span></span>
           </div>
         </div>
       </div>

--- a/js/controller.js
+++ b/js/controller.js
@@ -20,6 +20,7 @@
         RssService,
         StockService,
         ScrobblerService,
+        TVShowService,
         $rootScope, $scope, $timeout, $interval, tmhDynamicLocale, $translate) {
 
         // Local Scope Vars
@@ -553,6 +554,20 @@
                     $scope.focus = "timer";
                 }
             });
+
+            // Function to refresh TV show data
+            var refreshTVShows = function () {
+                console.log ("Refreshing TVShows");
+                $scope.tvshows = null;
+                TVShowService.refreshTVShows().then(function() {
+                  $scope.tvshows = TVShowService.getTVShows();
+                });
+            };
+
+            // Register refresh of TV shows once a day
+            if (typeof config.tvshows !== 'undefined'){
+                registerRefreshInterval(refreshTVShows, 24 * 60); // 24 hours * 60 min -- update once a day
+            }
         };
 
         _this.init();

--- a/js/controller.js
+++ b/js/controller.js
@@ -566,7 +566,7 @@
 
             // Register refresh of TV shows once a day
             if (typeof config.tvshows !== 'undefined'){
-                registerRefreshInterval(refreshTVShows, 24 * 60); // 24 hours * 60 min -- update once a day
+                registerRefreshInterval(refreshTVShows, config.tvshows.refreshInterval);
             }
         };
 

--- a/js/services/tvshows.js
+++ b/js/services/tvshows.js
@@ -1,7 +1,7 @@
 (function(annyang) {
   'use strict';
 
-  function TVShowService($window, $http, $q) {
+  function TVShowService($http, $q) {
     var service = {};
     service.shows = []; // hold show data here
 

--- a/js/services/tvshows.js
+++ b/js/services/tvshows.js
@@ -1,0 +1,48 @@
+(function(annyang) {
+  'use strict';
+
+  function TVShowService($window, $http, $q) {
+    var service = {};
+    service.shows = []; // hold show data here
+
+    service.init = function() {
+      var promises = [];
+      service.shows = [];
+
+      // for each show in config, create http request
+      angular.forEach(config.tvshows.shows, function(show) {
+      promises.push($http.get('http://epguides.frecar.no/show/' + show.replace(/\s|\./g, '') + '/next/')
+        .catch(function() { // if no response for a show add blank response, log error
+          console.log("No response for show: " + show);
+          return "";
+        }));
+      });
+
+      // resolve each http request, add response to service.shows
+      return $q.all(promises).then(function(response) {
+            for (var i = 0; i < response.length; i++) {
+                if (response[i].data != undefined) {
+                  service.shows.push(response[i]);
+                }
+            }
+      });
+    };
+
+    // call init, return entries
+    service.refreshTVShows = function() {
+      return service.init().then(function(entries) {
+        return entries;
+      });
+    };
+
+    // result of http requests
+    service.getTVShows = function() {
+      return service.shows;
+    };
+
+    return service;
+  }
+
+  angular.module('SmartMirror')
+    .factory('TVShowService', TVShowService);
+}(window.annyang));


### PR DESCRIPTION
Fixed the merge issues with the last pull request.

Service to track when the next episode of your favorite tv shows is going to air. Add a list of your TV shows in config.js, and they'll show up under stocks with their name and the next air date. If a next air date isn't available the show won't be displayed.

Makes use of the free API http://epguides.frecar.no/

Open to feedback -- what do you think would be better showing the next air date, or days until the next episode?