### PR TITLE
Make Traffic service more globally

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -106,7 +106,7 @@ var config = {
     },
     rss: {
         feeds: [],  // RSS feeds list - e.g. ["rss1.com", "rss2.com"]
-        refreshInterval: 120 // Number of minutes the information is refreshed
+        reload_interval: 120 // Number of minutes the information is refreshed
     },
     stock: {
         names: [] // The names of the stock quotes you with to show in the official format. (e.g.: 'YHOO','AAPL','GOOG')

--- a/js/services/traffic.js
+++ b/js/services/traffic.js
@@ -67,7 +67,7 @@
             if (trip.mode == "Driving") {
                 endpoint += "&avoid=minimizeTolls";
             } else if (trip.mode == "Transit") {
-                endpoint += "&timeType=Departure&dateTime=" + moment().format('h:mm:ssa').toUpperCase();
+                endpoint += "&timeType=Departure&dateTime=" + moment().lang("en").format('h:mm:ssa').toUpperCase();
             } else if (trip.mode == "Walking") {
                 endpoint += "&optmz=distance";
             }


### PR DESCRIPTION
Affected Service is traffic.
Bing Maps API requests a value of dateTime as "PM" or "AM".
but if user is living another country that is not using that format, then result of `moment().format('h:mm:ssa')` will be his own country format.
For example, In Korea, "PM" is "오후" & "AM" is "오전". so, it won't work in Bing Maps Request.

* And also change simple code in config.example.js because official document want that.