### PR TITLE
hotfix for tvservice - same as #506

### DIFF
--- a/plugins/tvshows/controller.js
+++ b/plugins/tvshows/controller.js
@@ -14,7 +14,9 @@ function TVShows($scope, $http, $interval) {
                     return "";
                 })
                 .then(function (response) {
-                    $scope.tvshows.push(response)
+                    if (response != "") {
+                        $scope.tvshows.push(response)
+                    }
                 })
         });
     }


### PR DESCRIPTION
####  Description
<!---Add your description here--->
...when multiple tv shows are not found.
Failed to load resource: the server responded with a status of 404 (NOT FOUND)
No response for show: big bang theory
Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: show in tvshows, Duplicate key: string:, Duplicate value:
http://errors.angularjs.org/1.5.9/ngRepeat/dupes?p0=show%20in%20tvshows&p1=string%3A&p2=
    at angular.js:68
    at ngRepeatAction (angular.js:30441)
    at $watchCollectionAction (angular.js:17617)
    at Scope.$digest (angular.js:17755)
    at Scope.$apply (angular.js:18021)
    at done (angular.js:12002)
    at completeRequest (angular.js:12211)
    at XMLHttpRequest.requestLoaded (angular.js:12139)

####  Fixes Related issues
fixes the angular errors likely the same @cwelinder mentioned on discord today...

needs to be pulled to master as well.

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have added config.schema.json file if config option are required.
- [ ] I am NOT targeting master branch
