### PR TITLE
darksky-fix

### DIFF
--- a/plugins/weather/controller.js
+++ b/plugins/weather/controller.js
@@ -5,9 +5,9 @@ function Weather($scope, $interval, $http, GeolocationService) {
 	var weather = {}
 
 	weather.get = function () {
-		return $http.jsonp('https://api.forecast.io/forecast/' + config.forecast.key + '/' +
+		return $http.get('https://api.darksky.net/forecast/' + config.forecast.key + '/' +
             geoposition.coords.latitude + ',' + geoposition.coords.longitude + '?units=' +
-            config.forecast.units + "&lang=" + language + "&callback=JSON_CALLBACK")
+            config.forecast.units + "&lang=" + language)
             .then(function (response) {
 	return weather.forecast = response;
 });


### PR DESCRIPTION


####  Description
<!---Add your description here--->
Shifted from `api.forecast.io` to `api.darksky.net`
Weather forecast didn't display with `jsonp` & `callback=JSON_CALLBACK`
param
Replaced `jsonp` with `get` and removed `callback` param.
Works now!
####  Fixes Related issues
- add related
- issues here

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have added config.schema.json file if config option are required.
- [x] I am NOT targeting master branch
