### PR TITLE
fix missing Focus change on monitor wake up.. issue 657

### DIFF
--- a/plugins/autosleep/service.js
+++ b/plugins/autosleep/service.js
@@ -43,6 +43,7 @@
 				service.woke = true;
 				if (config.autoTimer.mode == "monitor") {
 					service.exec(config.autoTimer.wakeCmd, service.puts);
+					Focus.change('default');
 				} else if (config.autoTimer.mode == "tv") {
 					Focus.change('default');
 				} else if (config.autoTimer.mode == "energy") {


### PR DESCRIPTION
####  Description
<!---Add your description here--->
when in autosleep mode with a Monitor device,, on wakeup, the Focus() is not restored

####  Fixes Related issues
- add related
- issues here
657

####  Checklist
- [ ] I have read and understand the CONTRIBUTIONS.md file
- [ ] I have searched for and linked related issues
- [ ] I have added config.schema.json file if config option are required.
- [ ] I am NOT targeting master branch
