### PR TITLE
use a different time humanizer to account for travel times over one hour

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "electron-json-storage": "2.0.0",
     "express": "^4.14.0",
     "fitbit-oauth2": "0.0.1",
+    "humanize-duration": "^3.10.1",
     "hyperion-client": "1.0.3",
     "moment": "^2.17.1",
     "socket.io": "^1.6.0",

--- a/plugins/traffic/controller.js
+++ b/plugins/traffic/controller.js
@@ -1,5 +1,10 @@
 function Traffic($scope, $http, $interval, $q, TimeboxService) {
-	var BING_MAPS = "http://dev.virtualearth.net/REST/V1/Routes/"
+	var BING_MAPS = "http://dev.virtualearth.net/REST/V1/Routes/";
+	var durationHumanizer = require('humanize-duration').humanizer({
+		language: config.general.language,
+		units: ['h', 'm'],
+		round: true
+	});
 
 	var getDurationForTrips = function () {
 		var deferred = $q.defer();
@@ -29,9 +34,9 @@ function Traffic($scope, $http, $interval, $q, TimeboxService) {
 		$http.get(getEndpoint(trip)).then(function (response) {
             // Walking and Transit are "not effected" by traffic so we don't use their traffic duration
 			if (trip.mode == "Transit" || trip.mode == "Walking") {
-				trip.duration = moment.duration(response.data.resourceSets[0].resources[0].travelDuration, 'seconds');
+				trip.duration = durationHumanizer(response.data.resourceSets[0].resources[0].travelDuration * 1000);
 			} else {
-				trip.duration = moment.duration(response.data.resourceSets[0].resources[0].travelDurationTraffic, 'seconds')
+				trip.duration = durationHumanizer(response.data.resourceSets[0].resources[0].travelDurationTraffic * 1000);
 			}
 
 			deferred.resolve(trip);

--- a/plugins/traffic/index.html
+++ b/plugins/traffic/index.html
@@ -2,7 +2,7 @@
     <div class="traffic" ng-repeat="traffic in trips">
         <div ng-show="!traffic.error" class="traffic-information">
             <span class="time-to" ng-bind="'traffic.time_to' | translate:traffic"></span>
-            <span ng-bind="traffic.duration.humanize()"></span>
+            <span ng-bind="traffic.duration"></span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
####  Description

use a different time humanizer to account for travel times over one hour

The `humanize` method of moment.js just returns the biggest unit, so it was always showing "1 hour" for my work way. [Described here](https://stackoverflow.com/a/19024225/4026792). I fixed it by adding the `humanize-duration` lib to convert it to hours and minutes. 

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have added config.schema.json file if config option are required.
- [x] I am NOT targeting master branch
