### PR TITLE
Format language to avoid errors when using the "humanize-duration" plugin

### DIFF
--- a/plugins/traffic/controller.js
+++ b/plugins/traffic/controller.js
@@ -1,7 +1,8 @@
 function Traffic($scope, $http, $interval, $q, TimeboxService) {
 	var BING_MAPS = "http://dev.virtualearth.net/REST/V1/Routes/";
+	var language = (typeof config.general.language !== 'undefined') ? config.general.language.substr(0, 2) : "en"
 	var durationHumanizer = require('humanize-duration').humanizer({
-		language: config.general.language,
+		language: language,
 		units: ['h', 'm'],
 		round: true
 	});


### PR DESCRIPTION

####  Description
The "humanize-duration" plugin, in the traffic plugin, was throwing the error: "No language undefined."

I copied logic from the weather plugin to format the language so it's recognizable to humanize-duration.

####  Fixes Related issues
None

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have added config.schema.json file if config option are required.
- [x] I am NOT targeting master branch
