### PR TITLE
Remove waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <p align="center">
 <a href="https://discord.gg/EMb4ynW"><img src="https://discordapp.com/api/guilds/258802311298547713/widget.png" alt="Discord Chat"/></a>
-<a href="https://waffle.io/evancohen/smart-mirror"><img src="https://img.shields.io/waffle/label/evancohen/smart-mirror/status%3A%20in%20progress.svg?label=in%20progress" alt="Stories in progress" /></a>
 <a href='https://travis-ci.org/evancohen/smart-mirror'><img src='https://travis-ci.org/evancohen/smart-mirror.svg?branch=master' alt='Build Status'/></a>
 </p>
 <p align="center">


### PR DESCRIPTION
####  Description
This commit removes the Waffle badge, as waffle.io no longer exists.

####  Fixes Related issues
Practically reverts #183 

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I am NOT targeting master branch
