### PR TITLE
add Electron options to config and startup 

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,11 +41,11 @@ let mainWindow
 
 function createWindow() {
  
-  if(config.general.electrionOptions){
-    for(var item of config.general.electrionOptions){
-      app.commandLine.appendSwitch(item.key, item.value)
-    }
-  }
+	if(config.general.electrionOptions){
+		for(var item of config.general.electrionOptions){
+			app.commandLine.appendSwitch(item.key, item.value)
+		}
+	}
   // Get the displays and render the mirror on a secondary screen if it exists
 	var atomScreen = electron.screen
 	var displays = atomScreen.getAllDisplays()

--- a/main.js
+++ b/main.js
@@ -40,7 +40,12 @@ try {
 let mainWindow
 
 function createWindow() {
-
+ 
+  if(config.general.electrionOptions){
+    for(var item of config.general.electrionOptions){
+      app.commandLine.appendSwitch(item.key, item.value)
+    }
+  }
   // Get the displays and render the mirror on a secondary screen if it exists
 	var atomScreen = electron.screen
 	var displays = atomScreen.getAllDisplays()

--- a/main.js
+++ b/main.js
@@ -40,10 +40,13 @@ try {
 let mainWindow
 
 function createWindow() {
- 
-	if(config.general.electrionOptions){
-		for(var item of config.general.electrionOptions){
-			app.commandLine.appendSwitch(item.key, item.value)
+  
+	if(config.general.electronOptions){
+		for(let option of config.general.electronOptions){
+			if(option.value == undefined)
+				app.commandLine.appendSwitch(option.key)
+			else
+				app.commandLine.appendSwitch(option.key, option.value )
 		}
 	}
   // Get the displays and render the mirror on a secondary screen if it exists

--- a/plugins/_general/config.schema.json
+++ b/plugins/_general/config.schema.json
@@ -9,36 +9,82 @@
                     "type": "string",
                     "title": "Language",
                     "required": true
-                },
+                    },
                 "layout": {
                     "default": "main",
                     "type": "string",
                     "title": "Layout",
                     "required": true
-                },
+                    },
                 "commandsPerPage":{
                     "default":10,
                     "type":"number",
                     "title": "Commands Per Page",
                     "required": true
-                }
+                    },
+                "electronOptions":{
+                    "title": "Electron Options",
+                    "type": "array",
+                        "items":{
+                          "type":"object",
+                          "title": "Option",
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                                "title": "key",
+                                "required": true
+                              },
+                              "value": {
+                                "type": "string",
+                                "title": "value"           
+                              }
+                            }
+                        }              
+                    }
             }
         }
     },
     "form":[
       {
-        "key":"general",
         "type":"fieldset",
         "title":"General Settings",
         "expandable":false,
-        "order":-100
+        "order":-100,
+        "items":[
+            { "key":"general.language","description":"Language"},
+            { "key":"general.layout","description":"CSS Layout"},
+            { "key":"general.commandsPerPage", "type":"number","description":"Commands Per Page"},
+            {
+              "type":"array",
+              "title":"Electron Options",
+              "expandable":true,              
+              "items":[
+                 {
+                  "type":"fieldset", 
+                  "title":"Option",
+                  "items":[
+                    {
+                    "key":"general.electronOptions[].key"
+                    },
+                    {
+                    "key":"general.electronOptions[].value"
+                    }
+                  ]
+                 }   
+               ]               
+            }              
+        ]
       }
     ],
     "value":{
         "general":{
             "language": "en-US",
             "layout":"main",
-            "commandsPerPage":10
+            "commandsPerPage":10,
+            "electronOptions":[
+               { "key": "autoplay-policy", "value": "no-user-gesture-required"},
+               { "key": "--disable-http-cache", "value": ""}
+            ]
         }
     }
 }


### PR DESCRIPTION
####  Description
new version of browsers have stopped autoplay of media, unless the user interacts with the web page somehow.  mirror users in general will never do that

the 'fix' is to add some electron commandline parms , which require code changes..

I have added config schema to hold the two know parms
disable cache for  image related apps
change autoplay-policy to 'no-user-gesture-required'

####  Fixes Related issues
#781 youtube autoplay no longer works
- issues here

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have added config.schema.json file if config option are required.
- [x] I am NOT targeting master branch
