### PR TITLE
add electron commandline options to enable autoplay and disable http …

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,8 @@ try {
 let mainWindow
 
 function createWindow() {
-
+  app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+  app.commandLine.appendSwitch('disable-http-cache');
   // Get the displays and render the mirror on a secondary screen if it exists
 	var atomScreen = electron.screen
 	var displays = atomScreen.getAllDisplays()

--- a/main.js
+++ b/main.js
@@ -40,8 +40,8 @@ try {
 let mainWindow
 
 function createWindow() {
-  app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
-  app.commandLine.appendSwitch('disable-http-cache');
+	app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+	app.commandLine.appendSwitch('disable-http-cache');
   // Get the displays and render the mirror on a secondary screen if it exists
 	var atomScreen = electron.screen
 	var displays = atomScreen.getAllDisplays()


### PR DESCRIPTION
 add electron commandline options to enable autoplay and disable http image caching

####  Description
new browsers have disabled autoplay of media, unless the user interacts with the web page somehow, mirror is hard to do that..  so youtube videos don't play

####  Fixes Related issues
#781 


####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have added config.schema.json file if config option are required.
- [x] I am NOT targeting master branch
