### PR TITLE
fix spotify defaults and improve usability and documentation

### DIFF
--- a/plugins/spotify/config.schema.json
+++ b/plugins/spotify/config.schema.json
@@ -17,7 +17,7 @@
         "position": {
           "type": "string",
           "title": "Default status indicator position ('top' or 'bottom')",
-          "default": "top"
+          "enum": ["top", "bottom"]
         },
         "creds": {
           "type": "object",
@@ -25,7 +25,8 @@
             "clientID": {
               "default": "",
               "type": "string",
-              "title": "OAuth 2.0 Client ID"
+              "title": "OAuth 2.0 Client ID",
+              "description":"You must define an application in your Spotify premium account, these two values will come from that definition you must also configure the autorization callback uri as described below "
             },
             "clientSecret": {
               "default": "",

--- a/remote/.config.default.json
+++ b/remote/.config.default.json
@@ -61,7 +61,17 @@
     "key": ""
   },
   "spotify": {
-    "key": ""
+    "creds": {    
+      "clientID":"",
+      "clientSecret":""
+    },
+    "authorization_uri":{
+      "scope": "activity nutrition profile settings sleep social weight heartrate",
+      "state": "3(#0/!~"
+    },        
+    "timeout":3600,
+    "default_device":"raspberry",
+    "position":"top"
   },
   "traffic": {
     "key": "",
@@ -97,5 +107,31 @@
       "scope": "activity nutrition profile settings sleep social weight heartrate",
       "state": "3(#0/!~"
     }
-  }
+  },
+  "plugins": [
+    {"name":"greeting","area":"middle-center", "order":"*", "active":true}, 
+    {"name":"remote","area":"middle-center", "order":"*", "active":true},
+    {"name":"soundcloud","area":"middle-center", "order":"*", "active":true},
+    {"name":"map","area":"middle-center", "order":"*", "active":true},
+    {"name":"xkcd","area":"middle-center", "order":"*", "active":true},
+    {"name":"dilbert","area":"middle-center", "order":"*", "active":true},
+    {"name":"commitstrip","area":"middle-center", "order":"*", "active":true},
+    {"name":"search","area":"middle-center", "order":"*", "active":true},
+    {"name":"giphy","area":"middle-center", "order":"*", "active":true},
+    {"name":"reminder","area":"middle-center", "order":"*", "active":true},
+    {"name":"timer","area":"middle-center", "order":"*", "active":true},
+    {"name":"todoist","area":"middle-center", "order":"*", "active":true}, 
+    {"name":"calendar","area":"top-left", "order":"2", "active":true},       
+    {"name":"weather","area":"top-right", "order":"1", "active":true},    
+    {"name":"datetime","area":"top-left", "order":"1", "active":true},  
+    {"name":"stock","area":"top-right", "order":"3", "active":true},    
+    {"name":"traffic","area":"top-right", "order":"2", "active":true},
+    {"name":"tvshows","area":"top-right", "order":"*", "active":true},
+    {"name":"ha-display","area":"top-right", "order":"*", "active":true},      
+    {"name":"commands","area":"bottom-center", "order":"*", "active":true},
+    {"name":"rss","area":"bottom-center", "order":"*", "active":true},   
+    {"name":"fitbit","area":"bottom-left", "order":"*", "active":true},
+    {"name":"scrobbler","area":"bottom-left", "order":"*", "active":true},  
+		{"name":"spotify","area":"bottom-left", "order":"*", "active":false}
+  ]
 }


### PR DESCRIPTION
####  Description
the defaults for spotify configuration are not  added to the config panel , update the defaults
change the top/bottom to an enum as these are the only two choices allowed. 

add text to describe what to do about adding an 'app' in the spotify account

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have added config.schema.json file if config option are required.
- [x] I am NOT targeting master branch
