### PR TITLE
Fix fitbit port to not collide with spotify plugin.. update auth process

### DIFF
--- a/plugins/fitbit/config.schema.json
+++ b/plugins/fitbit/config.schema.json
@@ -88,6 +88,10 @@
         "fitbit.creds",
         "fitbit.uris",
         "fitbit.authorization_uri"
+        {
+            "type": "help",
+            "helpvalue": "<p><b>Ensure the Fitbit API settings allow redirects from 'http://localhost:4100/fitbit_auth_callback'</b> then navigate to <a id='splink' onclick=\"document.getElementById('splink').href='http://'+window.location.hostname+':4100/fitbit/'; return true;\" target='_blank'>Authorize</a> from your mirror browser.</p>"
+        }
       ]
     }
   ],
@@ -101,7 +105,7 @@
         "tokenPath": "/oauth2/token"
       },
       "authorization_uri": {
-        "redirect_uri": "http://localhost:4000/fitbit_auth_callback/",
+        "redirect_uri": "http://localhost:4100/fitbit_auth_callback/",
         "response_type": "code",
         "scope": "activity nutrition profile settings sleep social weight heartrate",
         "state": "3(#0/!~"

--- a/plugins/fitbit/openauth.sh
+++ b/plugins/fitbit/openauth.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ chromium-browser -noerrdialogs -kiosk -start_maximized  --disable-infobars --app=$1  --ignore-certificate-errors-spki-list --ignore-ssl-errors --ignore-certificate-errors 2>/dev/null

--- a/plugins/fitbit/service.js
+++ b/plugins/fitbit/service.js
@@ -1,38 +1,41 @@
 (function () {
-	'use strict';
+	"use strict";
 
 	function FitbitService() {
-
 		var service = {};
 		var today = null;
 		var fitbit = {};
-		var tokenFile = 'fb-token.json';
+		var tokenFile = "fb-token.json";
 
 		/**
-         * Persist the fitbit token.
-         */
+		 * Persist the fitbit token.
+		 */
 		var persist = {
 			read: function (filename, cb) {
-				fs.readFile(filename, { encoding: 'utf8', flag: 'r' }, function (err, data) {
-					if (err) return cb(err);
-					try {
-						var token = JSON.parse(data);
-						cb(null, token);
-					} catch (err) {
-						cb(err);
+				fs.readFile(
+					filename,
+					{ encoding: "utf8", flag: "r" },
+					function (err, data) {
+						if (err) return cb(err);
+						try {
+							var token = JSON.parse(data);
+							cb(null, token);
+						} catch (err) {
+							cb(err);
+						}
 					}
-				});
+				);
 			},
 
 			write: function (filename, token, cb) {
-				console.debug('Persisting new token: ' + JSON.stringify(token));
+				console.debug("Persisting new token: " + JSON.stringify(token));
 				fs.writeFile(filename, JSON.stringify(token), cb);
-			}
+			},
 		};
 
 		/**
-         * Get today's date in the format YYYY-MM-DD. The date is used to 
-         */
+		 * Get today's date in the format YYYY-MM-DD. The date is used to
+		 */
 		service.getToday = function () {
 			var today = new Date();
 			var dd = today.getDate();
@@ -40,85 +43,114 @@
 			var yyyy = today.getFullYear();
 
 			if (dd < 10) {
-				dd = '0' + dd;
+				dd = "0" + dd;
 			}
 
 			if (mm < 10) {
-				mm = '0' + mm;
+				mm = "0" + mm;
 			}
 			// Add padding for the date, (we want 0x where x is the day or month number if its less than 10)
-			return yyyy + '-' + mm + '-' + dd;
-		}
+			return yyyy + "-" + mm + "-" + dd;
+		};
 
 		/**
-         * Instantiate the fitbit client.
-         */
-		if (typeof config.fitbit != 'undefined') {
-			var express = require('express');
+		 * Instantiate the fitbit client.
+		 */
+		if (typeof config.fitbit != "undefined") {
+			var express = require("express");
 			var app = express();
-			var fs = require('fs');
-			var Fitbit = require('fitbit-oauth2');
+			var fs = require("fs");
+			var Fitbit = require("fitbit-oauth2");
 
-			fitbit = new Fitbit(config.fitbit);
-			// In a browser, visit http://localhost:4000/fitbit to authorize a user for the first time.
-			app.get('/fitbit', function (req, res) {
-				res.redirect(fitbit.authorizeURL());
+			fitbit = new Fitbit(config.fitbit, function (err, token) {
+				if (!err) {
+					if (token && "access_token" in token) {
+						// persist the token
+						persist.write(tokenFile, token, function (err) {
+							if (err)
+								console.log("fitbit error writing token file");
+						});
+					}
+				}
+			});
+			// In a browser, visit http://localhost:4100/fitbit to authorize a user for the first time.
+			app.get("/fitbit", function (req, res) {
+				ley uri =  fitbit.authorizeURL()
+				// is this coming from the same machine
+				// no, spawn it
+				// issue #862
+				let source = req.ip == "::1" ? "localhost" : req.ip;
+				if (!source.endsWith(req.host)) {
+					let { spawn } = require("child_process");
+					spawn(__sp.resolve(_spotpath, "openauth.sh"), [uri]);
+					return res.send(
+						"Please see the web browser on your mirror for the final autorization steps<br>then you can close this page"
+					);
+				} else {
+					res.redirect(uri);
+				}
 			});
 
 			/*
-                Callback service parsing the authorization token and asking for the access token. 
+                Callback service parsing the authorization token and asking for the access token.
                 This endpoint is refered to in config.fitbit.authorization_uri.redirect_uri.
              */
-			app.get('/fitbit_auth_callback', function (req, res, next) {
+			app.get("/fitbit_auth_callback", function (req, res, next) {
 				var code = req.query.code;
-				fitbit.fetchToken(code, function (err, token) {
+				fitbit.fetchToken(code, function (err) {
 					if (err) return next(err);
-
-					// persist the token
-					persist.write(tokenFile, token, function (err) {
-						if (err) return next(err);
-						res.redirect('/fb-profile');
-					});
+					res.redirect("/fb-profile");
 				});
 			});
 
 			/*
-                Call an API. fitbit.request() mimics nodejs request() library, 
-                automatically adding the required oauth2 header. The callback 
-                is a bit different, called with (err, body, token). If token is 
-                non-null, this means a refresh has happened and you should 
+                Call an API. fitbit.request() mimics nodejs request() library,
+                automatically adding the required oauth2 header. The callback
+                is a bit different, called with (err, body, token). If token is
+                non-null, this means a refresh has happened and you should
                 persist the new token.
             */
-			app.get('/fb-profile', function (req, res, next) {
-				fitbit.request({
-					uri: "https://api.fitbit.com/1/user/-/profile.json",
-					method: 'GET',
-				}, function (err, body, token) {
-					if (err) {
-						return next(err);
+			app.get("/fb-profile", function (req, res, next) {
+				fitbit.request(
+					{
+						uri: "https://api.fitbit.com/1/user/-/profile.json",
+						method: "GET",
+					},
+					function (err, body, token) {
+						if (err) {
+							return next(err);
+						}
+
+						var profile = JSON.parse(body);
+
+						// If token is present, refresh.
+						if (token)
+							persist.write(tokenFile, token, function (err) {
+								if (err) return next(err);
+								res.send(
+									"<pre>" +
+										JSON.stringify(profile, null, 2) +
+										"</pre>"
+								);
+							});
+						else
+							res.send(
+								"<pre>" +
+									JSON.stringify(profile, null, 2) +
+									"</pre>"
+							);
 					}
-
-					var profile = JSON.parse(body);
-
-					// If token is present, refresh.
-					if (token)
-						persist.write(tokenFile, token, function (err) {
-							if (err) return next(err);
-							res.send('<pre>' + JSON.stringify(profile, null, 2) + '</pre>');
-						});
-					else
-						res.send('<pre>' + JSON.stringify(profile, null, 2) + '</pre>');
-				});
+				);
 			});
 		}
 
 		/**
-         * Init function
-         * If the fitbit configuration is present in the config.json, then express along with the fitbit service will be enabled.
-         */
+		 * Init function
+		 * If the fitbit configuration is present in the config.json, then express along with the fitbit service will be enabled.
+		 */
 		service.init = function (cb) {
-			var port = process.env.PORT || 4000;
-			console.debug('Express is listening on port: ' + port);
+			var port = process.env.PORT || 4100;
+			console.debug("Express is listening on port: " + port);
 			app.listen(port);
 
 			// Read the persisted token, initially captured by a webapp.
@@ -126,55 +158,60 @@
 				if (err == null) {
 					persist.read(tokenFile, function (err, token) {
 						if (err) {
-							console.error('Persist read error!', err);
+							console.error("Persist read error!", err);
 						}
 
 						fitbit.setToken(token); // Set the client token
-						cb()
+						cb();
 					});
-				} else if (err.code == 'ENOENT') {
-					console.error('Fitbit authentication required, please visit the following link: http://localhost:4000/fitbit to authenticate your credentials.', err);
+				} else if (err.code == "ENOENT") {
+					console.error(
+						"Fitbit authentication required, please visit the following link: http://localhost:"+port+"/fitbit to authenticate your credentials.",
+						err
+					);
 				} else {
 					console.error(err);
 				}
 			});
-		}
+		};
 
 		/**
-         * Profile Summary
-         * - Makes an API call to fitibt requesting the users profile summary.
-         */
+		 * Profile Summary
+		 * - Makes an API call to fitibt requesting the users profile summary.
+		 */
 		service.profileSummary = function (callback) {
 			if (service.summary === null) {
 				return null;
 			}
 
-			fitbit.request({
-				uri: "https://api.fitbit.com/1/user/-/profile.json",
-				method: 'GET',
-			}, function (err, body, token) {
-				if (err) {
-					console.log(err);
+			fitbit.request(
+				{
+					uri: "https://api.fitbit.com/1/user/-/profile.json",
+					method: "GET",
+				},
+				function (err, body, token) {
+					if (err) {
+						console.log(err);
+					}
+					var result = JSON.parse(body);
 
+					// If token is present, refresh.
+					if (token) {
+						persist.write(tokenFile, token, function (err) {
+							if (err) console.log(err);
+						});
+					}
+
+					//console.log(JSON.stringify(result));
+					return callback(result.user);
 				}
-				var result = JSON.parse(body);
-
-				// If token is present, refresh.
-				if (token) {
-					persist.write(tokenFile, token, function (err) {
-						if (err) console.log(err);
-					});
-				}
-
-				//console.log(JSON.stringify(result));
-				return callback(result.user);
-			});
-		}
+			);
+		};
 
 		/**
-         * Today's Summary
-         * - Makes a call to the fitbit API, requesting the summary of activities for today's date.
-         */
+		 * Today's Summary
+		 * - Makes a call to the fitbit API, requesting the summary of activities for today's date.
+		 */
 		service.todaySummary = function (callback) {
 			if (service.today === null) {
 				return null;
@@ -182,33 +219,37 @@
 
 			today = service.getToday();
 
-			fitbit.request({
-				uri: "https://api.fitbit.com/1/user/-/activities/date/" + today + ".json",
-				method: 'GET',
-			}, function (err, body, token) {
-				if (err) {
-					console.log(err);
+			fitbit.request(
+				{
+					uri:
+						"https://api.fitbit.com/1/user/-/activities/date/" +
+						today +
+						".json",
+					method: "GET",
+				},
+				function (err, body, token) {
+					if (err) {
+						console.log(err);
+					}
+					var result = JSON.parse(body);
+
+					// If token is present, refresh.
+					if (token) {
+						persist.write(tokenFile, token, function (err) {
+							if (err) console.log(err);
+						});
+					}
+
+					//console.log(JSON.stringify(result));
+					return callback(result);
 				}
-				var result = JSON.parse(body);
-
-				// If token is present, refresh.
-				if (token) {
-					persist.write(tokenFile, token, function (err) {
-						if (err) console.log(err);
-					});
-				}
-
-				//console.log(JSON.stringify(result));
-				return callback(result);
-			});
-
-
-		}
+			);
+		};
 
 		/**
-         * Sleep Summary
-         * - Makes a call to the fitbit API, requesting the summary of user's sleep from last night.
-         */
+		 * Sleep Summary
+		 * - Makes a call to the fitbit API, requesting the summary of user's sleep from last night.
+		 */
 		service.sleepSummary = function (callback) {
 			if (service.today === null) {
 				return null;
@@ -216,53 +257,62 @@
 
 			today = service.getToday();
 
-			fitbit.request({
-				uri: "https://api.fitbit.com/1/user/-/sleep/date/" + today + ".json",
-				method: 'GET',
-			}, function (err, body, token) {
-				if (err) {
-					console.log(err);
-				}
-				var result = JSON.parse(body);
+			fitbit.request(
+				{
+					uri:
+						"https://api.fitbit.com/1/user/-/sleep/date/" +
+						today +
+						".json",
+					method: "GET",
+				},
+				function (err, body, token) {
+					if (err) {
+						console.log(err);
+					}
+					var result = JSON.parse(body);
 
-				// If token is present, refresh.
-				if (token) {
-					persist.write(tokenFile, token, function (err) {
-						if (err) console.log(err);
-					});
-				}
+					// If token is present, refresh.
+					if (token) {
+						persist.write(tokenFile, token, function (err) {
+							if (err) console.log(err);
+						});
+					}
 
-				//console.log(JSON.stringify(result));
-				return callback(result);
-			});
-		}
+					//console.log(JSON.stringify(result));
+					return callback(result);
+				}
+			);
+		};
 
 		/**
-         * Device summary
-         * - Makes an API call to gather the information on the devices.
-         */
+		 * Device summary
+		 * - Makes an API call to gather the information on the devices.
+		 */
 		service.deviceSummary = function (callback) {
 			// Make an API call to get the users device status
-			fitbit.request({
-				uri: "https://api.fitbit.com/1/user/-/devices.json",
-				method: 'GET',
-			}, function (err, body, token) {
-				if (err) {
-					console.log(err);
-				}
-				var result = JSON.parse(body);
+			fitbit.request(
+				{
+					uri: "https://api.fitbit.com/1/user/-/devices.json",
+					method: "GET",
+				},
+				function (err, body, token) {
+					if (err) {
+						console.log(err);
+					}
+					var result = JSON.parse(body);
 
-				// If the token arg is not null, then a refresh has occured and
-				// we must persist the new token.
-				if (token) {
-					persist.write(tokenFile, token, function (err) {
-						if (err) console.log(err);
-					});
-				}
+					// If the token arg is not null, then a refresh has occured and
+					// we must persist the new token.
+					if (token) {
+						persist.write(tokenFile, token, function (err) {
+							if (err) console.log(err);
+						});
+					}
 
-				return callback(result);
-			});
-		}
+					return callback(result);
+				}
+			);
+		};
 
 		/**
 		 * Lifetime summary
@@ -270,55 +320,61 @@
 		 */
 		service.lifetimeSummary = function (callback) {
 			// Make an API call to get the users device status
-			fitbit.request({
-				uri: "https://api.fitbit.com/1/user/-/activities.json",
-				method: 'GET',
-			}, function (err, body, token) {
-				if (err) {
-					console.log(err);
+			fitbit.request(
+				{
+					uri: "https://api.fitbit.com/1/user/-/activities.json",
+					method: "GET",
+				},
+				function (err, body, token) {
+					if (err) {
+						console.log(err);
+					}
+					var result = JSON.parse(body);
+
+					// If the token arg is not null, then a refresh has occured and
+					// we must persist the new token.
+					if (token) {
+						persist.write(tokenFile, token, function (err) {
+							if (err) console.log(err);
+						});
+					}
+
+					//console.log(JSON.stringify(result));
+					return callback(result);
 				}
-				var result = JSON.parse(body);
-
-				// If the token arg is not null, then a refresh has occured and
-				// we must persist the new token.
-				if (token) {
-					persist.write(tokenFile, token, function (err) {
-						if (err) console.log(err);
-					});
-				}
-
-				//console.log(JSON.stringify(result));
-				return callback(result);
-			});
-		}
-
+			);
+		};
 
 		/**
 		 * Heart Rate
 		 */
 		service.heartRate = function (callback) {
 			// Make an API call to get the users device status
-			fitbit.request({
-				uri: "https://api.fitbit.com/1/user/-/activities/heart/date/today/1d.json",
-				method: 'GET',
-			}, function (err, body, token) {
-				if (err) {
-					console.log(err);
-				}
-				var result = JSON.parse(body);
+			fitbit.request(
+				{
+					uri:
+						"https://api.fitbit.com/1/user/-/activities/heart/date/today/1d.json",
+					method: "GET",
+				},
+				function (err, body, token) {
+					if (err) {
+						console.log(err);
+					}
+					var result = JSON.parse(body);
 
-				// If the token arg is not null, then a refresh has occured and
-				// we must persist the new token.
-				if (token) {
-					persist.write(tokenFile, token, function (err) {
-						if (err) console.log(err);
-					});
-				}
+					// If the token arg is not null, then a refresh has occured and
+					// we must persist the new token.
+					if (token) {
+						persist.write(tokenFile, token, function (err) {
+							if (err) console.log(err);
+						});
+					}
 
-				//console.log(JSON.stringify(result));
-				return callback(result);
-			});
-		}
+					//console.log(JSON.stringify(result));
+					return callback(result);
+				}
+			);
+		};
 		//Add Alarm
 		//POST https://api.fitbit.com/1/user/[user-id]/devices/tracker/[tracker-id]/alarms.json
 
@@ -334,7 +390,5 @@
 		return service;
 	}
 
-	angular.module('SmartMirror')
-		.factory('FitbitService', FitbitService);
-
-} ());
+	angular.module("SmartMirror").factory("FitbitService", FitbitService);
+})();

--- a/plugins/fitbit/service.js
+++ b/plugins/fitbit/service.js
@@ -1,3 +1,9 @@
+const __fbp = require("path");
+let _fbpath = document.currentScript.src.substring(
+	7,
+	document.currentScript.src.lastIndexOf(__fbp.sep)
+);
+
 (function () {
 	"use strict";
 
@@ -82,7 +88,7 @@
 				let source = req.ip == "::1" ? "localhost" : req.ip;
 				if (!source.endsWith(req.host)) {
 					let { spawn } = require("child_process");
-					spawn(__sp.resolve(_spotpath, "openauth.sh"), [uri]);
+					spawn(__fbp.resolve(_fbpath, "openauth.sh"), [uri]);
 					return res.send(
 						"Please see the web browser on your mirror for the final autorization steps<br>then you can close this page"
 					);

--- a/plugins/fitbit/service.js
+++ b/plugins/fitbit/service.js
@@ -75,7 +75,7 @@
 			});
 			// In a browser, visit http://localhost:4100/fitbit to authorize a user for the first time.
 			app.get("/fitbit", function (req, res) {
-				ley uri =  fitbit.authorizeURL()
+				let uri =  fitbit.authorizeURL()
 				// is this coming from the same machine
 				// no, spawn it
 				// issue #862


### PR DESCRIPTION
####  Description
change the auth callback port to 4100 to not collide with the spotify plugin auth requirements
make a clickable link from anywhere to launch the authorization request.. 
if browser here is localhost then redirect
if not here call app to launch chrome to get auth on the smart-mirror system

####  Checklist
- [x ] I have read and understand the CONTRIBUTIONS.md file
- [x ] I have searched for and linked related issues
- [x ] I have added config.schema.json file if config option are required.
- [x ] I am NOT targeting master branch
